### PR TITLE
feat: add NATS consumer config property AckWait

### DIFF
--- a/pubsub-lib/NatsClient.go
+++ b/pubsub-lib/NatsClient.go
@@ -38,12 +38,18 @@ const DefaultMaxAge time.Duration = 86400000000000
 
 type NatsClientConfig struct {
 	NatsServerHost string `env:"NATS_SERVER_HOST" envDefault:"nats://devtron-nats.devtroncd:4222"`
+
 	//consumer wise
 	NatsMsgProcessingBatchSize int `env:"NATS_MSG_PROCESSING_BATCH_SIZE" envDefault:"1"`
 	NatsMsgBufferSize          int `env:"NATS_MSG_BUFFER_SIZE" envDefault:"64"`
+
 	//stream wise
 	NatsStreamConfig string `env:"NATS_STREAM_CONFIG" envDefault:"{\"max_age\":86400000000000}"`
+
+	// Consumer config
+	NatsConsumerConfig string `env:"NATS_CONSUMER_CONFIG" envDefault:"{\"ackWaitInSecs\":3600}"`
 }
+
 type StreamConfig struct {
 	MaxAge time.Duration `json:"max_age"`
 }
@@ -53,6 +59,7 @@ type NatsStreamConfig struct {
 type NatsConsumerConfig struct {
 	NatsMsgProcessingBatchSize int `json:"natsMsgProcessingBatchSize"`
 	NatsMsgBufferSize          int `json:"natsMsgBufferSize"`
+	AckWaitInSecs              int `json:"ackWaitInSecs"`
 }
 
 /* #nosec */

--- a/pubsub-lib/PubSubClientService.go
+++ b/pubsub-lib/PubSubClientService.go
@@ -84,10 +84,40 @@ func (impl PubSubClientServiceImpl) Subscribe(topic string, callback func(msg *P
 	}
 	processingBatchSize := NatsConsumerWiseConfigMapping[consumerName].NatsMsgProcessingBatchSize
 	msgBufferSize := NatsConsumerWiseConfigMapping[consumerName].NatsMsgBufferSize
-	//processingBatchSize := natsClient.NatsMsgProcessingBatchSize
-	//msgBufferSize := natsClient.NatsMsgBufferSize
+
+	// Converting provided ack wait (int) into duration for comparing with nats-server config
+	ackWait := time.Duration(NatsConsumerWiseConfigMapping[consumerName].AckWaitInSecs) * time.Second
+
+	// Get the current Consumer config from NATS-server
+	info, err := natsClient.JetStrCtxt.ConsumerInfo(streamName, consumerName)
+
+	if err != nil {
+		impl.Logger.Errorw("unable to retrieve consumer info from NATS-server",
+			"stream", streamName,
+			"consumer", consumerName,
+			"err", err)
+
+	} else {
+		// Update NATS Consumer config if new changes detected
+		// Currently only checking for AckWait, but can be done for other editable properties as well
+
+		if ackWait > 0 && info.Config.AckWait != ackWait {
+
+			updatedConfig := info.Config
+			updatedConfig.AckWait = ackWait
+
+			_, err = natsClient.JetStrCtxt.UpdateConsumer(streamName, &updatedConfig)
+
+			if err != nil {
+				impl.Logger.Errorw("failed to update Consumer config",
+					"received consumer config", info.Config,
+					"err", err)
+			}
+		}
+	}
+
 	channel := make(chan *nats.Msg, msgBufferSize)
-	_, err := natsClient.JetStrCtxt.ChanQueueSubscribe(topic, queueName, channel, nats.Durable(consumerName), deliveryOption, nats.ManualAck(),
+	_, err = natsClient.JetStrCtxt.ChanQueueSubscribe(topic, queueName, channel, nats.Durable(consumerName), deliveryOption, nats.ManualAck(),
 		nats.BindStream(streamName))
 	if err != nil {
 		impl.Logger.Fatalw("error while subscribing to nats ", "stream", streamName, "topic", topic, "error", err)
@@ -116,7 +146,7 @@ func (impl PubSubClientServiceImpl) processMessages(wg *sync.WaitGroup, channel 
 	}
 }
 
-//TODO need to extend msg ack depending upon response from callback like error scenario
+// TODO need to extend msg ack depending upon response from callback like error scenario
 func (impl PubSubClientServiceImpl) processMsg(msg *nats.Msg, callback func(msg *PubSubMsg)) {
 	timeLimitInMillSecs := impl.logsConfig.DefaultLogTimeLimit * 1000
 	t1 := time.Now()


### PR DESCRIPTION
# Description
Earlier AckWait Consumer config was default set to 30s and value could not be updated, to update it one had to recreate the consumer group with updated value. With this change every time the orchestrator starts it will first compare the change between NATS-server consumer config and provided config and if there is any it will update it