### PR TITLE
feat: ext cluster blob issue

### DIFF
--- a/blob-storage/AwsS3Blob.go
+++ b/blob-storage/AwsS3Blob.go
@@ -31,12 +31,7 @@ func (impl *AwsS3Blob) UploadBlob(request *BlobStorageRequest, err error) error 
 	}
 
 	command := exec.Command("aws", cmdArgs...)
-	if s3BaseConfig.AccessKey != "" && s3BaseConfig.Passkey != "" {
-		command.Env = append(os.Environ(),
-			fmt.Sprintf("AWS_ACCESS_KEY_ID=%s", s3BaseConfig.AccessKey),
-			fmt.Sprintf("AWS_SECRET_ACCESS_KEY=%s", s3BaseConfig.Passkey),
-		)
-	}
+	setAWSEnvironmentVariables(s3BaseConfig, command)
 	err = utils.RunCommand(command)
 	return err
 }

--- a/blob-storage/AwsS3Blob.go
+++ b/blob-storage/AwsS3Blob.go
@@ -21,6 +21,10 @@ type AwsS3Blob struct{}
 func (impl *AwsS3Blob) UploadBlob(request *BlobStorageRequest, err error) error {
 	s3BaseConfig := request.AwsS3BaseConfig
 	var cmdArgs []string
+	var credentialsString string
+	if s3BaseConfig.AccessKey != "" && s3BaseConfig.Passkey != "" {
+		credentialsString = fmt.Sprintf("export AWS_ACCESS_KEY_ID=%s ; export AWS_SECRET_ACCESS_KEY=%s ; ", s3BaseConfig.AccessKey, s3BaseConfig.Passkey)
+	}
 	destinationFileString := fmt.Sprintf("s3://%s/%s", s3BaseConfig.BucketName, request.DestinationKey)
 	cmdArgs = append(cmdArgs, "s3", "cp", request.SourceKey, destinationFileString)
 	if s3BaseConfig.EndpointUrl != "" {
@@ -29,7 +33,8 @@ func (impl *AwsS3Blob) UploadBlob(request *BlobStorageRequest, err error) error 
 	if s3BaseConfig.Region != "" {
 		cmdArgs = append(cmdArgs, "--region", s3BaseConfig.Region)
 	}
-	command := exec.Command("aws", cmdArgs...)
+
+	command := exec.Command(credentialsString+"aws", cmdArgs...)
 	err = utils.RunCommand(command)
 	return err
 }

--- a/blob-storage/Bean.go
+++ b/blob-storage/Bean.go
@@ -25,6 +25,43 @@ type BlobStorageS3Config struct {
 	CiArtifactBucketVersioning bool   `json:"ciArtifactBucketVersioning"`
 }
 
+func (b *BlobStorageS3Config) GetBlobStorageBaseS3Config(blobStorageObjectType string) *AwsS3BaseConfig {
+	switch blobStorageObjectType {
+	case BlobStorageObjectTypeCache:
+		return &AwsS3BaseConfig{
+			AccessKey:         b.AccessKey,
+			Passkey:           b.Passkey,
+			EndpointUrl:       b.EndpointUrl,
+			IsInSecure:        b.IsInSecure,
+			BucketName:        b.CiCacheBucketName,
+			Region:            b.CiCacheRegion,
+			VersioningEnabled: b.CiCacheBucketVersioning,
+		}
+	case BlobStorageObjectTypeLog:
+		return &AwsS3BaseConfig{
+			AccessKey:         b.AccessKey,
+			Passkey:           b.Passkey,
+			EndpointUrl:       b.EndpointUrl,
+			IsInSecure:        b.IsInSecure,
+			BucketName:        b.CiLogBucketName,
+			Region:            b.CiLogRegion,
+			VersioningEnabled: b.CiLogBucketVersioning,
+		}
+	case BlobStorageObjectTypeArtifact:
+		return &AwsS3BaseConfig{
+			AccessKey:         b.AccessKey,
+			Passkey:           b.Passkey,
+			EndpointUrl:       b.EndpointUrl,
+			IsInSecure:        b.IsInSecure,
+			BucketName:        b.CiArtifactBucketName,
+			Region:            b.CiArtifactRegion,
+			VersioningEnabled: b.CiArtifactBucketVersioning,
+		}
+	default:
+		return nil
+	}
+}
+
 type AwsS3BaseConfig struct {
 	AccessKey         string `json:"accessKey"`
 	Passkey           string `json:"passkey"`
@@ -44,6 +81,34 @@ type AzureBlobConfig struct {
 	AccountKey            string `json:"accountKey"`
 }
 
+func (b *AzureBlobConfig) GetBlobStorageBaseAzureConfig(blobStorageObjectType string) *AzureBlobBaseConfig {
+	switch blobStorageObjectType {
+	case BlobStorageObjectTypeCache:
+		return &AzureBlobBaseConfig{
+			Enabled:           b.Enabled,
+			AccountName:       b.AccountName,
+			AccountKey:        b.AccountKey,
+			BlobContainerName: b.BlobContainerCiCache,
+		}
+	case BlobStorageObjectTypeLog:
+		return &AzureBlobBaseConfig{
+			Enabled:           b.Enabled,
+			AccountName:       b.AccountName,
+			AccountKey:        b.AccountKey,
+			BlobContainerName: b.BlobContainerCiLog,
+		}
+	case BlobStorageObjectTypeArtifact:
+		return &AzureBlobBaseConfig{
+			Enabled:           b.Enabled,
+			AccountName:       b.AccountName,
+			AccountKey:        b.AccountKey,
+			BlobContainerName: b.BlobContainerArtifact,
+		}
+	default:
+		return nil
+	}
+}
+
 type AzureBlobBaseConfig struct {
 	Enabled           bool   `json:"enabled"`
 	AccountName       string `json:"accountName"`
@@ -58,6 +123,28 @@ type GcpBlobConfig struct {
 	ArtifactBucketName     string `json:"artifactBucketName"`
 }
 
+func (b *GcpBlobConfig) GetBlobStorageBaseS3Config(blobStorageObjectType string) *GcpBlobBaseConfig {
+	switch blobStorageObjectType {
+	case BlobStorageObjectTypeCache:
+		return &GcpBlobBaseConfig{
+			BucketName:             b.CacheBucketName,
+			CredentialFileJsonData: b.CredentialFileJsonData,
+		}
+	case BlobStorageObjectTypeLog:
+		return &GcpBlobBaseConfig{
+			BucketName:             b.LogBucketName,
+			CredentialFileJsonData: b.CredentialFileJsonData,
+		}
+	case BlobStorageObjectTypeArtifact:
+		return &GcpBlobBaseConfig{
+			BucketName:             b.ArtifactBucketName,
+			CredentialFileJsonData: b.CredentialFileJsonData,
+		}
+	default:
+		return nil
+	}
+}
+
 type GcpBlobBaseConfig struct {
 	BucketName             string `json:"bucketName"`
 	CredentialFileJsonData string `json:"credentialFileData"`
@@ -66,8 +153,11 @@ type GcpBlobBaseConfig struct {
 type BlobStorageType string
 
 const (
-	BLOB_STORAGE_AZURE BlobStorageType = "AZURE"
-	BLOB_STORAGE_S3                    = "S3"
-	BLOB_STORAGE_GCP                   = "GCP"
-	BLOB_STORAGE_MINIO                 = "MINIO"
+	BLOB_STORAGE_AZURE            BlobStorageType = "AZURE"
+	BLOB_STORAGE_S3                               = "S3"
+	BLOB_STORAGE_GCP                              = "GCP"
+	BLOB_STORAGE_MINIO                            = "MINIO"
+	BlobStorageObjectTypeCache                    = "cache"
+	BlobStorageObjectTypeArtifact                 = "artifact"
+	BlobStorageObjectTypeLog                      = "log"
 )

--- a/blob-storage/Bean.go
+++ b/blob-storage/Bean.go
@@ -25,34 +25,6 @@ type BlobStorageS3Config struct {
 	CiArtifactBucketVersioning bool   `json:"ciArtifactBucketVersioning"`
 }
 
-func (b *BlobStorageS3Config) GetBlobStorageBaseS3Config(blobStorageObjectType string) *AwsS3BaseConfig {
-	awsS3BaseConfig := &AwsS3BaseConfig{
-		AccessKey:         b.AccessKey,
-		Passkey:           b.Passkey,
-		EndpointUrl:       b.EndpointUrl,
-		IsInSecure:        b.IsInSecure,
-	}
-	switch blobStorageObjectType {
-	case BlobStorageObjectTypeCache:
-		awsS3BaseConfig.BucketName = b.CiCacheBucketName
-		awsS3BaseConfig.Region = b.CiCacheRegion
-		awsS3BaseConfig.VersioningEnabled = b.CiCacheBucketVersioning
-		return awsS3BaseConfig
-	case BlobStorageObjectTypeLog:
-		awsS3BaseConfig.BucketName = b.CiLogBucketName
-		awsS3BaseConfig.Region = b.CiLogRegion
-		awsS3BaseConfig.VersioningEnabled = b.CiLogBucketVersioning
-		return awsS3BaseConfig
-	case BlobStorageObjectTypeArtifact:
-		awsS3BaseConfig.BucketName = b.CiArtifactBucketName
-		awsS3BaseConfig.Region = b.CiArtifactRegion
-		awsS3BaseConfig.VersioningEnabled = b.CiArtifactBucketVersioning
-		return awsS3BaseConfig
-	default:
-		return nil
-	}
-}
-
 type AwsS3BaseConfig struct {
 	AccessKey         string `json:"accessKey"`
 	Passkey           string `json:"passkey"`
@@ -72,27 +44,6 @@ type AzureBlobConfig struct {
 	AccountKey            string `json:"accountKey"`
 }
 
-func (b *AzureBlobConfig) GetBlobStorageBaseAzureConfig(blobStorageObjectType string) *AzureBlobBaseConfig {
-	azureBlobBaseConfig := &AzureBlobBaseConfig{
-		Enabled:     b.Enabled,
-		AccountName: b.AccountName,
-		AccountKey:  b.AccountKey,
-	}
-	switch blobStorageObjectType {
-	case BlobStorageObjectTypeCache:
-		azureBlobBaseConfig.BlobContainerName = b.BlobContainerCiCache
-		return azureBlobBaseConfig
-	case BlobStorageObjectTypeLog:
-		azureBlobBaseConfig.BlobContainerName = b.BlobContainerCiLog
-		return azureBlobBaseConfig
-	case BlobStorageObjectTypeArtifact:
-		azureBlobBaseConfig.BlobContainerName = b.BlobContainerArtifact
-		return azureBlobBaseConfig
-	default:
-		return nil
-	}
-}
-
 type AzureBlobBaseConfig struct {
 	Enabled           bool   `json:"enabled"`
 	AccountName       string `json:"accountName"`
@@ -107,25 +58,6 @@ type GcpBlobConfig struct {
 	ArtifactBucketName     string `json:"artifactBucketName"`
 }
 
-func (b *GcpBlobConfig) GetBlobStorageBaseGcpConfig(blobStorageObjectType string) *GcpBlobBaseConfig {
-	gcpBlobBaseConfig := &GcpBlobBaseConfig{
-		CredentialFileJsonData: b.CredentialFileJsonData
-	}
-	switch blobStorageObjectType {
-	case BlobStorageObjectTypeCache:
-		gcpBlobBaseConfig.BucketName = b.CacheBucketName
-		return gcpBlobBaseConfig
-	case BlobStorageObjectTypeLog:
-		gcpBlobBaseConfig.BucketName = b.LogBucketName
-		return gcpBlobBaseConfig
-	case BlobStorageObjectTypeArtifact:
-		gcpBlobBaseConfig.BucketName = b.ArtifactBucketName
-		return gcpBlobBaseConfig
-	default:
-		return nil
-	}
-}
-
 type GcpBlobBaseConfig struct {
 	BucketName             string `json:"bucketName"`
 	CredentialFileJsonData string `json:"credentialFileData"`
@@ -134,11 +66,8 @@ type GcpBlobBaseConfig struct {
 type BlobStorageType string
 
 const (
-	BLOB_STORAGE_AZURE            BlobStorageType = "AZURE"
-	BLOB_STORAGE_S3                               = "S3"
-	BLOB_STORAGE_GCP                              = "GCP"
-	BLOB_STORAGE_MINIO                            = "MINIO"
-	BlobStorageObjectTypeCache                    = "cache"
-	BlobStorageObjectTypeArtifact                 = "artifact"
-	BlobStorageObjectTypeLog                      = "log"
+	BLOB_STORAGE_AZURE BlobStorageType = "AZURE"
+	BLOB_STORAGE_S3                    = "S3"
+	BLOB_STORAGE_GCP                   = "GCP"
+	BLOB_STORAGE_MINIO                 = "MINIO"
 )

--- a/blob-storage/Bean.go
+++ b/blob-storage/Bean.go
@@ -123,7 +123,7 @@ type GcpBlobConfig struct {
 	ArtifactBucketName     string `json:"artifactBucketName"`
 }
 
-func (b *GcpBlobConfig) GetBlobStorageBaseS3Config(blobStorageObjectType string) *GcpBlobBaseConfig {
+func (b *GcpBlobConfig) GetBlobStorageBaseGcpConfig(blobStorageObjectType string) *GcpBlobBaseConfig {
 	switch blobStorageObjectType {
 	case BlobStorageObjectTypeCache:
 		return &GcpBlobBaseConfig{

--- a/blob-storage/Bean.go
+++ b/blob-storage/Bean.go
@@ -26,37 +26,28 @@ type BlobStorageS3Config struct {
 }
 
 func (b *BlobStorageS3Config) GetBlobStorageBaseS3Config(blobStorageObjectType string) *AwsS3BaseConfig {
+	awsS3BaseConfig := &AwsS3BaseConfig{
+		AccessKey:         b.AccessKey,
+		Passkey:           b.Passkey,
+		EndpointUrl:       b.EndpointUrl,
+		IsInSecure:        b.IsInSecure,
+	}
 	switch blobStorageObjectType {
 	case BlobStorageObjectTypeCache:
-		return &AwsS3BaseConfig{
-			AccessKey:         b.AccessKey,
-			Passkey:           b.Passkey,
-			EndpointUrl:       b.EndpointUrl,
-			IsInSecure:        b.IsInSecure,
-			BucketName:        b.CiCacheBucketName,
-			Region:            b.CiCacheRegion,
-			VersioningEnabled: b.CiCacheBucketVersioning,
-		}
+		awsS3BaseConfig.BucketName = b.CiCacheBucketName
+		awsS3BaseConfig.Region = b.CiCacheRegion
+		awsS3BaseConfig.VersioningEnabled = b.CiCacheBucketVersioning
+		return awsS3BaseConfig
 	case BlobStorageObjectTypeLog:
-		return &AwsS3BaseConfig{
-			AccessKey:         b.AccessKey,
-			Passkey:           b.Passkey,
-			EndpointUrl:       b.EndpointUrl,
-			IsInSecure:        b.IsInSecure,
-			BucketName:        b.CiLogBucketName,
-			Region:            b.CiLogRegion,
-			VersioningEnabled: b.CiLogBucketVersioning,
-		}
+		awsS3BaseConfig.BucketName = b.CiLogBucketName
+		awsS3BaseConfig.Region = b.CiLogRegion
+		awsS3BaseConfig.VersioningEnabled = b.CiLogBucketVersioning
+		return awsS3BaseConfig
 	case BlobStorageObjectTypeArtifact:
-		return &AwsS3BaseConfig{
-			AccessKey:         b.AccessKey,
-			Passkey:           b.Passkey,
-			EndpointUrl:       b.EndpointUrl,
-			IsInSecure:        b.IsInSecure,
-			BucketName:        b.CiArtifactBucketName,
-			Region:            b.CiArtifactRegion,
-			VersioningEnabled: b.CiArtifactBucketVersioning,
-		}
+		awsS3BaseConfig.BucketName = b.CiArtifactBucketName
+		awsS3BaseConfig.Region = b.CiArtifactRegion
+		awsS3BaseConfig.VersioningEnabled = b.CiArtifactBucketVersioning
+		return awsS3BaseConfig
 	default:
 		return nil
 	}
@@ -82,28 +73,21 @@ type AzureBlobConfig struct {
 }
 
 func (b *AzureBlobConfig) GetBlobStorageBaseAzureConfig(blobStorageObjectType string) *AzureBlobBaseConfig {
+	azureBlobBaseConfig := &AzureBlobBaseConfig{
+		Enabled:     b.Enabled,
+		AccountName: b.AccountName,
+		AccountKey:  b.AccountKey,
+	}
 	switch blobStorageObjectType {
 	case BlobStorageObjectTypeCache:
-		return &AzureBlobBaseConfig{
-			Enabled:           b.Enabled,
-			AccountName:       b.AccountName,
-			AccountKey:        b.AccountKey,
-			BlobContainerName: b.BlobContainerCiCache,
-		}
+		azureBlobBaseConfig.BlobContainerName = b.BlobContainerCiCache
+		return azureBlobBaseConfig
 	case BlobStorageObjectTypeLog:
-		return &AzureBlobBaseConfig{
-			Enabled:           b.Enabled,
-			AccountName:       b.AccountName,
-			AccountKey:        b.AccountKey,
-			BlobContainerName: b.BlobContainerCiLog,
-		}
+		azureBlobBaseConfig.BlobContainerName = b.BlobContainerCiLog
+		return azureBlobBaseConfig
 	case BlobStorageObjectTypeArtifact:
-		return &AzureBlobBaseConfig{
-			Enabled:           b.Enabled,
-			AccountName:       b.AccountName,
-			AccountKey:        b.AccountKey,
-			BlobContainerName: b.BlobContainerArtifact,
-		}
+		azureBlobBaseConfig.BlobContainerName = b.BlobContainerArtifact
+		return azureBlobBaseConfig
 	default:
 		return nil
 	}
@@ -124,22 +108,19 @@ type GcpBlobConfig struct {
 }
 
 func (b *GcpBlobConfig) GetBlobStorageBaseGcpConfig(blobStorageObjectType string) *GcpBlobBaseConfig {
+	gcpBlobBaseConfig := &GcpBlobBaseConfig{
+		CredentialFileJsonData: b.CredentialFileJsonData
+	}
 	switch blobStorageObjectType {
 	case BlobStorageObjectTypeCache:
-		return &GcpBlobBaseConfig{
-			BucketName:             b.CacheBucketName,
-			CredentialFileJsonData: b.CredentialFileJsonData,
-		}
+		gcpBlobBaseConfig.BucketName = b.CacheBucketName
+		return gcpBlobBaseConfig
 	case BlobStorageObjectTypeLog:
-		return &GcpBlobBaseConfig{
-			BucketName:             b.LogBucketName,
-			CredentialFileJsonData: b.CredentialFileJsonData,
-		}
+		gcpBlobBaseConfig.BucketName = b.LogBucketName
+		return gcpBlobBaseConfig
 	case BlobStorageObjectTypeArtifact:
-		return &GcpBlobBaseConfig{
-			BucketName:             b.ArtifactBucketName,
-			CredentialFileJsonData: b.CredentialFileJsonData,
-		}
+		gcpBlobBaseConfig.BucketName = b.ArtifactBucketName
+		return gcpBlobBaseConfig
 	default:
 		return nil
 	}

--- a/blob-storage/BlobUtils.go
+++ b/blob-storage/BlobUtils.go
@@ -1,0 +1,16 @@
+package blob_storage
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func setAWSEnvironmentVariables(s3Config *AwsS3BaseConfig, command *exec.Cmd) {
+	if s3Config.AccessKey != "" && s3Config.Passkey != "" {
+		command.Env = append(os.Environ(),
+			fmt.Sprintf("AWS_ACCESS_KEY_ID=%s", s3Config.AccessKey),
+			fmt.Sprintf("AWS_SECRET_ACCESS_KEY=%s", s3Config.Passkey),
+		)
+	}
+}


### PR DESCRIPTION
Previously AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY were not being passed as env variable in common lib, it was set in env var in orch, but this pr aims at setting AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY as env for aws in common lib