### PR TITLE
chore: reverted the implimentation for Nats ShutDown

### DIFF
--- a/pubsub-lib/NatsClient.go
+++ b/pubsub-lib/NatsClient.go
@@ -108,8 +108,8 @@ func (consumerConf NatsConsumerConfig) GetNatsMsgBufferSize() int {
 // }
 
 func NewNatsClient(logger *zap.SugaredLogger) (*NatsClient, error) {
-	connWg := new(sync.WaitGroup)
-	connWg.Add(1)
+	//connWg := new(sync.WaitGroup)
+	//connWg.Add(1)
 	cfg := &NatsClientConfig{}
 	err := env.Parse(cfg)
 	if err != nil {
@@ -131,7 +131,7 @@ func NewNatsClient(logger *zap.SugaredLogger) (*NatsClient, error) {
 		}),
 		nats.ClosedHandler(func(nc *nats.Conn) {
 			logger.Errorw("Nats Client Connection closed!", "Reason", nc.LastError())
-			connWg.Done()
+			//connWg.Done()
 		}))
 	if err != nil {
 		logger.Error("err", err)
@@ -149,7 +149,7 @@ func NewNatsClient(logger *zap.SugaredLogger) (*NatsClient, error) {
 		logger:     logger,
 		JetStrCtxt: js,
 		Conn:       nc,
-		ConnWg:     connWg,
+		//ConnWg:     connWg,
 	}
 	return natsClient, nil
 }

--- a/pubsub-lib/PubSubClientService.go
+++ b/pubsub-lib/PubSubClientService.go
@@ -78,11 +78,13 @@ func NewPubSubClientServiceImpl(logger *zap.SugaredLogger) (*PubSubClientService
 
 func (impl PubSubClientServiceImpl) ShutDown() error {
 	// Drain the connection, which will close it when done.
-	if err := impl.NatsClient.Conn.Drain(); err != nil {
-		return err
-	}
+	//if err := impl.NatsClient.Conn.Drain(); err != nil {
+	//	return err
+	//}
 	// Wait for the connection to be closed.
-	impl.NatsClient.ConnWg.Wait()
+	//impl.NatsClient.ConnWg.Wait()
+	// TODO: Currently the drain mechanism deletes the Ephemeral consumers.
+	//       Implement the fix for the Ephemeral consumers first to enable graceful shutdown.
 	return nil
 }
 


### PR DESCRIPTION
Currently we create Ephemeral consumers by NATS Subscribe method. but with the introduction of NATS graceful shutdown using Drain() function. the NATS client deletes durable consumers that it created during QueueSubscribe(). Need to properly handle this condition first until then reverting the graceful shutdown implementation.
