### PR TITLE
fix: reverse proxy panic noises

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -38,13 +38,14 @@ const (
 
 // metrics name constants
 const (
-	NATS_PUBLISH_COUNT          = "nats_publish_count"
-	NATS_CONSUMPTION_COUNT      = "nats_consumption_count"
-	NATS_CONSUMING_COUNT        = "nats_consuming_count"
-	NATS_EVENT_CONSUMPTION_TIME = "nats_event_consumption_time"
-	NATS_EVENT_PUBLISH_TIME     = "nats_event_publish_time"
-	NATS_EVENT_DELIVERY_COUNT   = "nats_event_delivery_count"
-	PANIC_RECOVERY_COUNT        = "panic_recovery_count"
+	NATS_PUBLISH_COUNT                 = "nats_publish_count"
+	NATS_CONSUMPTION_COUNT             = "nats_consumption_count"
+	NATS_CONSUMING_COUNT               = "nats_consuming_count"
+	NATS_EVENT_CONSUMPTION_TIME        = "nats_event_consumption_time"
+	NATS_EVENT_PUBLISH_TIME            = "nats_event_publish_time"
+	NATS_EVENT_DELIVERY_COUNT          = "nats_event_delivery_count"
+	PANIC_RECOVERY_COUNT               = "panic_recovery_count"
+	REVERSE_PROXY_PANIC_RECOVERY_COUNT = "reverse_proxy_panic_recovery_count"
 )
 
 // metrics labels constant

--- a/pubsub-lib/metrics/metrics.go
+++ b/pubsub-lib/metrics/metrics.go
@@ -53,6 +53,10 @@ var PanicRecoveryCount = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: constants.PANIC_RECOVERY_COUNT,
 }, []string{constants.PANIC_TYPE, constants.HOST, constants.METHOD, constants.PATH})
 
+var ReverseProxyPanicRecoveryCount = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: constants.REVERSE_PROXY_PANIC_RECOVERY_COUNT,
+}, []string{constants.PANIC_TYPE, constants.HOST, constants.METHOD, constants.PATH})
+
 func IncPublishCount(topic, status string) {
 	NatsPublishingCount.WithLabelValues(topic, status).Inc()
 }
@@ -64,6 +68,11 @@ func IncConsumptionCount(topic string) {
 func IncConsumingCount(topic string) {
 	NatsConsumingCount.WithLabelValues(topic).Inc()
 }
+
 func IncPanicRecoveryCount(panicType, host, method, path string) {
 	PanicRecoveryCount.WithLabelValues(panicType, host, method, path).Inc()
+}
+
+func IncReverseProxyPanicRecoveryCount(panicType, host, method, path string) {
+	ReverseProxyPanicRecoveryCount.WithLabelValues(panicType, host, method, path).Inc()
 }


### PR DESCRIPTION
## Description:
Suppressing the reverse proxy panic noises. 

### for references:
https://pkg.go.dev/net/http#ErrAbortHandler
https://github.com/golang/go/issues/28239 

Fixes https://github.com/devtron-labs/devops-sprint/issues/843